### PR TITLE
🎨 fix: color codes in error messages

### DIFF
--- a/src/apis/jina_cloud.py
+++ b/src/apis/jina_cloud.py
@@ -265,6 +265,10 @@ def shorten_logs(relevant_lines):
     return relevant_lines
 
 
+def clean_color_codes(response):
+    response = re.sub(r'\x1b\[[0-9;]*m', '', response)
+    return response
+
 def process_error_message(error_message):
     lines = error_message.split('\n')
 
@@ -283,6 +287,8 @@ def process_error_message(error_message):
     relevant_lines = shorten_logs(relevant_lines)
 
     response = '\n'.join(relevant_lines[-100:]).strip()
+
+    response = clean_color_codes(response)
 
     # the following code tests the case that the docker file is corrupted and can not be parsed
     # the method above will not return a relevant error message in this case

--- a/test/test_strings.py
+++ b/test/test_strings.py
@@ -1,0 +1,11 @@
+from src.apis.jina_cloud import clean_color_codes
+
+
+def test_clean_color_codes():
+    color_start = f"\033[{31}m"
+    reset = "\033[0m"
+    bold_start = "\033[1m"
+    color = f"{bold_start}{color_start}test{reset}"
+    cleaned = clean_color_codes(color)
+    print('with color codes:', color)
+    print('without color codes:', cleaned)


### PR DESCRIPTION
During debugging it can happen that the error message contains color resets. Those are now filtered out.
<img width="266" alt="image" src="https://user-images.githubusercontent.com/11627845/233350476-e2d4eff3-96be-43ae-9f27-54a3b21ec3ef.png">
