### PR TITLE
feat: enhance package generation

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -38,5 +38,7 @@ DEMO_TOKEN = '45372338e04f5a41af949024db929d46'
 
 PROBLEMATIC_PACKAGES = [
     # 'Pyrender', 'Trimesh',
-    'ModernGL', 'PyOpenGL', 'Pyglet', 'pythreejs', 'panda3d' # because they need a screen
+    'ModernGL', 'PyOpenGL', 'Pyglet', 'pythreejs', 'panda3d', # because they need a screen,
 ]
+
+UNNECESSARY_PACKAGES = ['FastAPI']

--- a/src/options/generate/templates_user.py
+++ b/src/options/generate/templates_user.py
@@ -97,7 +97,7 @@ template_generate_executor = PromptTemplate.from_template(
 Write the executor called '{microservice_name}'. The name is very important to keep.
 It matches the following description: '{microservice_description}'.
 It will be tested with the following scenario: '{test_description}'.
-For the implementation use the following package: '{packages}'.
+For the implementation use the following package(s): '{packages}'.
 
 Obey the following rules:
 Have in mind that d.uri is never a path to a local file. It is always a url.
@@ -105,10 +105,11 @@ Have in mind that d.uri is never a path to a local file. It is always a url.
 
 Your approach:
 1. Identify the core challenge when implementing the executor.
-2. Think about solutions for these challenges.
+2. Think about solutions for these challenges. Use gpt_3_5_turbo_api if it is mentioned in the above list of packages.
 3. Decide for one of the solutions.
 4. Write the code for the executor. Don't write code for the test.
-If you decided to use gpt, then the executor must include the following code:
+If you decided to use gpt or if gpt_3_5_turbo_api is in the package list, then you must always include the following code in microservice.py:
+```
 import os
 import openai
 openai.api_key = os.getenv("OPENAI_API_KEY")
@@ -129,9 +130,10 @@ class GPT_3_5_Turbo_API:
             }}]
         )
         return response.choices[0]['message']['content']
+```
 
 
-''' + '\n' + template_code_wrapping_string
+''' + template_code_wrapping_string
 )
 
 
@@ -141,7 +143,7 @@ template_generate_test = PromptTemplate.from_template(
 {code_files_wrapped}
 
 Write a single test case that tests the following scenario: '{test_description}'. In case the test scenario is not precise enough, test a general case without any assumptions.
-Start the test with an extensive comment about the test case.
+Start the test with an extensive comment about the test case. If gpt_3_5_turbo_api is used in the executor, then the test must not check the exact output of the executor as it is not deterministic. 
 
 Use the following import to import the executor:
 ```
@@ -152,6 +154,7 @@ from microservice import {microservice_name}
 The test must not open local files.
 The test must not mock a function of the executor.
 The test must not use other data than the one provided in the test scenario.
+The test must not set any environment variables which require a key.
 ''' + '\n' + template_code_wrapping_string
 )
 
@@ -231,9 +234,8 @@ You are given the following files:
 
 {all_files_string}
 
-Output all the files that need change. 
-Don't output files that don't need change. If you output a file, then write the 
-complete file. Use the exact following syntax to wrap the code:
+Output all the files that need change. If you change microservice.py and it uses gpt_3_5_turbo_api, then you must keep the code for gpt_3_5_turbo_api to the microservice.py file.
+Don't output files that don't need change. If you output a file, then write the complete file. Use the exact following syntax to wrap the code:
 
 **...**
 ```

--- a/src/options/generate/templates_user.py
+++ b/src/options/generate/templates_user.py
@@ -108,7 +108,7 @@ Your approach:
 2. Think about solutions for these challenges. Use gpt_3_5_turbo_api if it is mentioned in the above list of packages.
 3. Decide for one of the solutions.
 4. Write the code for the executor. Don't write code for the test.
-If you decided to use gpt or if gpt_3_5_turbo_api is in the package list, then you must always include the following code in microservice.py:
+If and only if gpt_3_5_turbo_api is in the package list, then you must always include the following code in microservice.py:
 ```
 import os
 import openai

--- a/src/options/generate/templates_user.py
+++ b/src/options/generate/templates_user.py
@@ -234,8 +234,8 @@ You are given the following files:
 
 {all_files_string}
 
-Output all the files that need change. If you change microservice.py and it uses gpt_3_5_turbo_api, then you must keep the code for gpt_3_5_turbo_api to the microservice.py file.
-Don't output files that don't need change. If you output a file, then write the complete file. Use the exact following syntax to wrap the code:
+Output all the files that need change. Don't output files that don't need change.
+If you output a file, then write the complete file. Use the exact following syntax to wrap the code:
 
 **...**
 ```
@@ -276,8 +276,9 @@ Obey the following rules:
 ''' + f'{not_allowed_executor_string}\n{not_allowed_docker_string}' + '''
 
 Output all the files that need change. 
-Don't output files that don't need change. If you output a file, then write the 
-complete file. Use the exact following syntax to wrap the code:
+Don't output files that don't need change. If you output a file, then write the complete file.
+If you change microservice.py and it uses gpt_3_5_turbo_api, then you must keep the code for gpt_3_5_turbo_api to the microservice.py file.
+Use the exact following syntax to wrap the code:
 
 **...**
 ```...

--- a/src/options/generate/templates_user.py
+++ b/src/options/generate/templates_user.py
@@ -277,7 +277,7 @@ Obey the following rules:
 
 Output all the files that need change. 
 Don't output files that don't need change. If you output a file, then write the complete file.
-If you change microservice.py and it uses gpt_3_5_turbo_api, then you must keep the code for gpt_3_5_turbo_api to the microservice.py file.
+If you change microservice.py and it uses gpt_3_5_turbo_api, then you must keep the code for gpt_3_5_turbo_api in the microservice.py file.
 Use the exact following syntax to wrap the code:
 
 **...**

--- a/src/options/generate/templates_user.py
+++ b/src/options/generate/templates_user.py
@@ -48,7 +48,7 @@ PDFParserExecutor
 
 
 template_generate_possible_packages_output_format_string = '''You must output the package combinations as a list of lists wrapped into ``` and name it **packages.csv**. Do not use quotation marks around packages names in the output. Separate packages in a combination by comma. The output looks this:
-**packages.csv**
+**{file_name}**
 ```
 package1a, package1b ...
 package2a, package2b, package2c

--- a/src/options/generate/templates_user.py
+++ b/src/options/generate/templates_user.py
@@ -313,8 +313,8 @@ print(response[0].text) # can also be blob in case of image/audio..., this shoul
 ```
 Note that the response will always be in response[0].text
 The playground displays a code block containing the microservice specific curl code that can be used to send the request to the microservice.
-Example: 
-
+While the exact payload in the curl might change, the host and deployment ID always stay the same. Example: 
+```
 deployment_id = os.environ.get("K8S_NAMESPACE_NAME", "")
 host = f'https://gptdeploy-{{deployment_id.split("-")[1]}}.wolf.jina.ai/post' if deployment_id else "http://localhost:8080/post"
 with st.expander("See curl command"):
@@ -322,7 +322,7 @@ with st.expander("See curl command"):
         f'curl -X \\'POST\\' \\'host\\' -H \\'accept: application/json\\' -H \\'Content-Type: application/json\\' -d \\'{{{{"data": [{{{{"text": "hello, world!"}}}}]}}}}\\'',
         language='bash'
     )
-
+```
 You must provide the complete app.py file using the following syntax to wrap the code:
 **app.py**
 ```python


### PR DESCRIPTION
Enhances package generation (esp. for GPT-3.5-turbo):
- asks to define different strategies to solve the issue (for GPT-3.5-turbo: only asking for sub-problems leads to outlining one strategy and `summarise a text` became `Ranking sentences based on the frequency of their words to form a summary.` as main goal)
- improve outputting of packages and ask if they couldn't be parsed
- improve texts describing custom GPT-3.5-turbo API
- fixes issue that debugging iterator can remove custom GPT API (for GPT-3.5-turbo)