### PR TITLE
⬆ fix: retry executor push

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read_requirements():
 
 setup(
     name='gptdeploy',
-    version='0.18.26',
+    version='0.18.27',
     description='Use natural language interface to generate, deploy and update your microservice infrastructure.',
     long_description=open('README.md', 'r', encoding='utf-8').read(),
     long_description_content_type='text/markdown',

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.18.26'
+__version__ = '0.18.27'
 from src.cli import main

--- a/src/apis/jina_cloud.py
+++ b/src/apis/jina_cloud.py
@@ -62,6 +62,16 @@ In this case, please cancel this run, rerun your gptdeploy command and login int
 
 
 def push_executor(dir_path):
+    for i in range(3):
+        try:
+            return _push_executor(dir_path)
+        except Exception as e:
+            if i == 2:
+                raise e
+            print(f'connection error - retrying in 5 seconds...')
+            time.sleep(5)
+
+def _push_executor(dir_path):
     dir_path = Path(dir_path)
     md5_hash = hashlib.md5()
     bytesio = archive_package(dir_path)


### PR DESCRIPTION
Sometimes the hubble api fails. Therefore we introduce retries.