### PR TITLE
⏩ fix: fail fast bad executor

### DIFF
--- a/src/apis/jina_cloud.py
+++ b/src/apis/jina_cloud.py
@@ -131,6 +131,14 @@ def _push_executor(dir_path):
             responses.append(d)
     return '\n'.join(responses)
 
+def is_microservice_in_hub(microservice_name):
+    url = f'https://api.hubble.jina.ai/v2/rpc/executor.list?search={microservice_name}&withAnonymous=true'
+    resp = requests.get(url)
+    executor_list = resp.json()['data']
+    for executor in executor_list:
+        if 'name' in executor and executor['name'] == microservice_name:
+            return True
+    return False
 
 def get_user_name(token=None):
     client = hubble.Client(max_retries=None, jsonify=True, token=token)

--- a/src/apis/jina_cloud.py
+++ b/src/apis/jina_cloud.py
@@ -131,7 +131,7 @@ def _push_executor(dir_path):
             responses.append(d)
     return '\n'.join(responses)
 
-def is_microservice_in_hub(microservice_name):
+def is_executor_in_hub(microservice_name):
     url = f'https://api.hubble.jina.ai/v2/rpc/executor.list?search={microservice_name}&withAnonymous=true'
     resp = requests.get(url)
     executor_list = resp.json()['data']

--- a/src/options/generate/generator.py
+++ b/src/options/generate/generator.py
@@ -205,8 +205,14 @@ metas:
                 if i == MAX_DEBUGGING_ITERATIONS - 1:
                     raise self.MaxDebugTimeReachedException('Could not debug the microservice.')
             else:
-                print('Successfully build microservice.')
-                break
+                # at the moment, there can be cases where no error log is extracted but the executor is still not published
+                # it leads to problems later on when someone tries a run or deployment
+                if is_microservice_in_hub(microservice_name):
+                    print('Successfully build microservice.')
+                    break
+                else:
+                    raise Exception(log_hubble)
+
 
         return get_microservice_path(path, microservice_name, packages, num_approach, i)
 

--- a/src/options/generate/generator.py
+++ b/src/options/generate/generator.py
@@ -5,7 +5,7 @@ import shutil
 from typing import List
 
 from src.apis import gpt
-from src.apis.jina_cloud import process_error_message, push_executor
+from src.apis.jina_cloud import process_error_message, push_executor, is_executor_in_hub
 from src.constants import FILE_AND_TAG_PAIRS, NUM_IMPLEMENTATION_STRATEGIES, MAX_DEBUGGING_ITERATIONS, \
     PROBLEMATIC_PACKAGES, EXECUTOR_FILE_NAME, EXECUTOR_FILE_TAG, TEST_EXECUTOR_FILE_NAME, TEST_EXECUTOR_FILE_TAG, \
     REQUIREMENTS_FILE_NAME, REQUIREMENTS_FILE_TAG, DOCKER_FILE_NAME, DOCKER_FILE_TAG, UNNECESSARY_PACKAGES
@@ -190,6 +190,9 @@ metas:
         # push the gateway
         print('Final step...')
         hubble_log = push_executor(gateway_path)
+        if not is_executor_in_hub(gateway_name):
+            raise Exception(f'{microservice_name} not in hub. Hubble logs: {hubble_log}')
+
 
     def debug_microservice(self, path, microservice_name, num_approach, packages):
         for i in range(1, MAX_DEBUGGING_ITERATIONS):
@@ -207,11 +210,11 @@ metas:
             else:
                 # at the moment, there can be cases where no error log is extracted but the executor is still not published
                 # it leads to problems later on when someone tries a run or deployment
-                if is_microservice_in_hub(microservice_name):
+                if is_executor_in_hub(microservice_name):
                     print('Successfully build microservice.')
                     break
                 else:
-                    raise Exception(log_hubble)
+                    raise Exception(f'{microservice_name} not in hub. Hubble logs: {log_hubble}')
 
 
         return get_microservice_path(path, microservice_name, packages, num_approach, i)

--- a/test/test_hub.py
+++ b/test/test_hub.py
@@ -1,0 +1,6 @@
+from src.apis.jina_cloud import is_microservice_in_hub
+
+
+def test_is_microservice_in_hub():
+    assert is_microservice_in_hub('reoihoflsnvoiawejeruhvflsfk') is False
+    assert is_microservice_in_hub('CLIPImageEncoder') is True

--- a/test/test_hub.py
+++ b/test/test_hub.py
@@ -1,6 +1,6 @@
-from src.apis.jina_cloud import is_microservice_in_hub
+from src.apis.jina_cloud import is_executor_in_hub
 
 
 def test_is_microservice_in_hub():
-    assert is_microservice_in_hub('reoihoflsnvoiawejeruhvflsfk') is False
-    assert is_microservice_in_hub('CLIPImageEncoder') is True
+    assert is_executor_in_hub('reoihoflsnvoiawejeruhvflsfk') is False
+    assert is_executor_in_hub('CLIPImageEncoder') is True


### PR DESCRIPTION
The after debugging the executor must be pushed. Here, we add the validation that this is actually the case. If not, then we output the most recend raw log generated by hubble.